### PR TITLE
feat: add ApplicationResourceMonitorJob for memory and CPU tracking

### DIFF
--- a/Core/JobScheduler.cs
+++ b/Core/JobScheduler.cs
@@ -2,6 +2,7 @@
 using Microsoft.Extensions.Configuration;
 using Microsoft.Extensions.Hosting;
 using Microsoft.Extensions.Logging;
+using JobRunner.Utils;
 
 namespace JobRunner.Core
 {
@@ -15,73 +16,111 @@ namespace JobRunner.Core
         private readonly IEnumerable<IJobTask> _tasks = tasks;
         private readonly IEnumerable<JobSchedule> _schedules = schedules;
         private readonly ILogger<JobScheduler> _logger = logger;
-
         private readonly bool _runAllJobsInPreview = configuration.GetValue<bool>("RunAllJobsInPreview");
 
         protected override async Task ExecuteAsync(CancellationToken stoppingToken)
         {
             _logger.LogInformation("🚦 Job scheduler starting...");
 
-            foreach (var schedule in _schedules)
+            if (!_schedules.Any())
             {
-                if (!schedule.Enabled)
-                {
-                    _logger.LogInformation("⏭️  Skipping disabled job: {JobName}", schedule.JobName);
-                    continue;
-                }
+                _logger.LogWarning("⚠️ No jobs configured.");
+                return;
+            }
 
+            LogConfiguredJobs();
+
+            foreach (var schedule in _schedules.Where(s => s.Enabled))
+            {
                 var task = _tasks.FirstOrDefault(t => t.Name == schedule.JobName);
                 if (task == null)
                 {
-                    _logger.LogWarning("❌ No task found for job: {JobName}", schedule.JobName);
+                    _logger.LogWarning("❓ No task found for job: {JobName}", schedule.JobName);
                     continue;
                 }
 
+                var isPreview = schedule.IsPreview || _runAllJobsInPreview;
                 var context = new JobContext
                 {
                     Logger = _logger,
                     Parameters = schedule.Parameters
                 };
 
-                bool isPreview = schedule.IsPreview || _runAllJobsInPreview;
-
-                if (task is IPreviewableJob previewJob && isPreview)
+                if (task is IPreviewableJob previewable && isPreview)
                 {
-                    _logger.LogInformation("📝 Preview mode enabled for: {JobName}", schedule.JobName);
-                    _ = Task.Run(() => previewJob.PreviewAsync(context, stoppingToken), stoppingToken);
+                    _ = Task.Run(() => previewable.PreviewAsync(context, stoppingToken), stoppingToken);
                 }
                 else
                 {
-                    _logger.LogInformation("⏰ Scheduling job: {JobName} every {Interval}", schedule.JobName, schedule.Interval);
-                    _ = RunOnIntervalAsync(task, schedule, stoppingToken);
+                    _ = RunOnIntervalAsync(task, schedule, context, stoppingToken);
                 }
             }
 
             await Task.CompletedTask;
         }
 
-        private async Task RunOnIntervalAsync(IJobTask task, JobSchedule schedule, CancellationToken token)
+        private void LogConfiguredJobs()
         {
+            _logger.LogInformation("📦 Jobs configured:");
+            var count = _schedules.Count();
+
+            for (int i = 0; i < count; i++)
+            {
+                var schedule = _schedules.ElementAt(i);
+                var isLast = i == count - 1;
+                var prefix = isLast ? "└─" : "├─";
+                var status = schedule.Enabled ? "✅" : "❌";
+                var preview = schedule.IsPreview || _runAllJobsInPreview ? " 🧪" : "";
+
+                _logger.LogInformation(" {Prefix} {Status} {JobName}{Preview} ⏱️ Every {Interval}",
+                    prefix, status, schedule.JobName, preview, schedule.Interval);
+            }
+        }
+
+        private async Task RunOnIntervalAsync(IJobTask task, JobSchedule schedule, JobContext context, CancellationToken token)
+        {
+            var jobIcon = GetJobIcon(schedule.JobName);
+            var outputBuffer = new StringWriter();
+            var logCapture = context.Logger;
+
+            // Replace the logger with one that writes to a buffer (if you want cleaner batching)
+            var bufferedLogger = new BufferedLogger(logCapture, outputBuffer);
+
+            var runContext = new JobContext
+            {
+                Logger = bufferedLogger,
+                Parameters = context.Parameters
+            };
+
             while (!token.IsCancellationRequested)
             {
-                var context = new JobContext
-                {
-                    Logger = _logger,
-                    Parameters = schedule.Parameters
-                };
-
                 try
                 {
-                    _logger.LogInformation("✅ Executing {JobName}", schedule.JobName);
-                    await task.ExecuteAsync(context, token);
+                    await task.ExecuteAsync(runContext, token);
+                    var jobOutput = outputBuffer.ToString().Trim();
+
+                    if (!string.IsNullOrEmpty(jobOutput))
+                    {
+                        _logger.LogInformation("{Icon} {JobName} run result:\n{Output}", jobIcon, schedule.JobName, jobOutput);
+                    }
                 }
                 catch (Exception ex)
                 {
-                    _logger.LogError(ex, "💥 Error executing {JobName}", task.Name);
+                    _logger.LogError(ex, "❌ Error executing {JobName}", schedule.JobName);
                 }
 
+                outputBuffer.GetStringBuilder().Clear(); // Clear between runs
                 await Task.Delay(schedule.Interval, token);
             }
         }
+
+        private static string GetJobIcon(string jobName) => jobName switch
+        {
+            "PingJob" => "📡",
+            "DiskCleanupJob" => "🧹",
+            "GitHubStarTrackerJob" => "⭐",
+            "ApplicationResourceMonitorJob" => "📊",
+            _ => "🧩"
+        };
     }
 }

--- a/Jobs/ApplicationResourceMonitorJob.cs
+++ b/Jobs/ApplicationResourceMonitorJob.cs
@@ -1,0 +1,72 @@
+﻿using JobRunner.Core;
+using Microsoft.Extensions.Logging;
+using System.Diagnostics;
+
+namespace JobRunner.Jobs
+{
+    public class ApplicationResourceMonitorJob : IPreviewableJob
+    {
+        public string Name => "ApplicationResourceMonitorJob";
+
+        public async Task ExecuteAsync(JobContext context, CancellationToken cancellationToken)
+        {
+            await Run(context, preview: false, cancellationToken);
+        }
+
+        public async Task PreviewAsync(JobContext context, CancellationToken cancellationToken)
+        {
+            await Run(context, preview: true, cancellationToken);
+        }
+
+        private static async Task Run(JobContext context, bool preview, CancellationToken token)
+        {
+            var logger = context.Logger;
+            var parameters = context.Parameters;
+
+            var process = Process.GetCurrentProcess();
+
+            var usedMemoryMb = process.WorkingSet64 / (1024 * 1024);
+            var cpuUsage = await GetCpuUsageForProcessAsync(process, token);
+
+            logger.LogInformation("📦 Application Memory Usage: {Used} MB", usedMemoryMb);
+            logger.LogInformation("🧮 Application CPU Usage: {Usage:F2}%", cpuUsage);
+
+            if (!preview)
+            {
+                if (parameters.TryGetValue("MaxMemoryMB", out var memStr) &&
+                    int.TryParse(memStr, out var memThreshold) &&
+                    usedMemoryMb > memThreshold)
+                {
+                    logger.LogWarning("⚠️ Memory usage exceeded: {Used} MB > {Threshold} MB", usedMemoryMb, memThreshold);
+                }
+
+                if (parameters.TryGetValue("MaxCpuPercent", out var cpuStr) &&
+                    float.TryParse(cpuStr, out var cpuThreshold) &&
+                    cpuUsage > cpuThreshold)
+                {
+                    logger.LogWarning("⚠️ CPU usage exceeded: {Used:F2}% > {Threshold}%", cpuUsage, cpuThreshold);
+                }
+            }
+
+            await Task.CompletedTask;
+        }
+
+        private static async Task<double> GetCpuUsageForProcessAsync(Process process, CancellationToken token)
+        {
+            var startTime = DateTime.UtcNow;
+            var startCpu = process.TotalProcessorTime;
+
+            // Wait 500ms to sample CPU
+            await Task.Delay(500, token);
+
+            var endTime = DateTime.UtcNow;
+            var endCpu = process.TotalProcessorTime;
+
+            var cpuUsedMs = (endCpu - startCpu).TotalMilliseconds;
+            var elapsedMs = (endTime - startTime).TotalMilliseconds;
+            var cpuUsageTotal = cpuUsedMs / (Environment.ProcessorCount * elapsedMs) * 100;
+
+            return cpuUsageTotal;
+        }
+    }
+}

--- a/Jobs/PingJob.cs
+++ b/Jobs/PingJob.cs
@@ -1,5 +1,6 @@
 ﻿using JobRunner.Core;
 using Microsoft.Extensions.Logging;
+using System.Text;
 
 namespace JobRunner.Jobs
 {
@@ -8,36 +9,40 @@ namespace JobRunner.Jobs
         public string Name => "PingJob";
 
         public async Task ExecuteAsync(JobContext context, CancellationToken cancellationToken)
-        {
-            await Run(context, preview: false, cancellationToken);
-        }
+            => await Run(context, preview: false, cancellationToken);
 
         public async Task PreviewAsync(JobContext context, CancellationToken cancellationToken)
-        {
-            await Run(context, preview: true, cancellationToken);
-        }
+            => await Run(context, preview: true, cancellationToken);
 
         private static async Task Run(JobContext context, bool preview, CancellationToken cancellationToken)
         {
             var logger = context.Logger;
+            var logBuilder = new StringBuilder();
+
+            void LogInfo(string msg) => logBuilder.AppendLine(msg);
+            void LogError(string msg) => logBuilder.AppendLine(msg);
+
             var url = context.Parameters.TryGetValue("Url", out var value) ? value : "https://example.com";
 
             if (preview)
             {
-                logger.LogInformation("📝 Preview: Would ping {Url}", url);
-                return;
+                LogInfo($"Preview: Would ping {url}");
+            }
+            else
+            {
+                try
+                {
+                    using var http = new HttpClient();
+                    var response = await http.GetAsync(url, cancellationToken);
+                    LogInfo($"Pinged {url} -> {response.StatusCode}");
+                }
+                catch (Exception ex)
+                {
+                    LogError($"Failed to reach {url}: {ex.Message}");
+                }
             }
 
-            try
-            {
-                using var http = new HttpClient();
-                var response = await http.GetAsync(url, cancellationToken);
-                logger.LogInformation("📡 {Url} -> {StatusCode}", url, response.StatusCode);
-            }
-            catch (Exception ex)
-            {
-                logger.LogError(ex, "❌ Failed to reach {Url}", url);
-            }
+            logger.LogInformation("{BatchLog}", logBuilder.ToString().TrimEnd());
         }
     }
 }

--- a/Program.cs
+++ b/Program.cs
@@ -50,6 +50,7 @@ try
             services.AddSingleton<IJobTask, PingJob>();
             services.AddSingleton<IJobTask, DiskCleanupJob>();
             services.AddSingleton<IJobTask, GitHubStarTrackerJob>();
+            services.AddSingleton<IJobTask, ApplicationResourceMonitorJob>();
 
             // Register background scheduler
             services.AddHostedService<JobScheduler>();

--- a/Program.cs
+++ b/Program.cs
@@ -41,9 +41,7 @@ try
             }
             else
             {
-                logger.Information("📦 Loaded {Count} job(s): {Jobs}",
-                    jobList.Count,
-                    string.Join(", ", jobList.Select(j => $"{j.JobName} ⏱️ {j.Interval}")));
+                logger.Information("📦 Loaded {Count} job(s): {Jobs}", jobList.Count, string.Join(", ", jobList.Select(j => j.JobName)));
             }
 
             // Register job implementations

--- a/README.md
+++ b/README.md
@@ -98,14 +98,13 @@ services.AddSingleton<IJobTask, MyNewJob>();
 
 ## 📌 Roadmap Ideas
 - [x] ✅ `PingJob` – Periodically ping a URL and log the status code
-- [x] 🧹 **Disk Cleanup Job** – Recursively delete files older than X days from a target folder
-- [x] 📝 Preview mode support for all jobs (dry-run without executing logic)
-- [ ] ⭐ **GitHub Star Tracker** – Poll a GitHub repo for stars, track and alert on increases
-- [ ] 🧠 Memory monitor or disk usage job
+- [x] 🧹 `DiskCleanupJob` – Recursively delete files older than X days from a target folder
+- [x] ⭐ `GitHubStarTrackerJob` – Poll GitHub repo for star count and log changes
+- [x] 📦 `ApplicationResourceMonitorJob` – Monitor current app’s memory/CPU usage and alert if limits are exceeded
 - [ ] 📨 Email/Slack/webhook alerting system
-- [ ] 📦 Plugin-based job discovery (load jobs from external assemblies)
 - [ ] 📊 CSV/JSON file processor job
 - [ ] 🕸️ Broken link checker (scan websites for 404s)
+- [ ] 📦 Plugin-based job discovery (load jobs from external assemblies)
 
 ---
 

--- a/Utils/BufferedLogger.cs
+++ b/Utils/BufferedLogger.cs
@@ -1,0 +1,38 @@
+﻿using Microsoft.Extensions.Logging;
+
+namespace JobRunner.Utils
+{
+    public class BufferedLogger(ILogger inner, StringWriter buffer) : ILogger
+    {
+        private readonly ILogger _inner = inner;
+        private readonly StringWriter _buffer = buffer;
+
+        IDisposable ILogger.BeginScope<TState>(TState state) => _inner.BeginScope(state) ?? NullScope.Instance;
+
+        public void Log<TState>(LogLevel logLevel, EventId eventId,
+            TState state, Exception? exception, Func<TState, Exception?, string> formatter)
+        {
+            var message = formatter(state, exception);
+            _buffer.WriteLine(GetPrefix(logLevel) + " " + message);
+        }
+
+        private sealed class NullScope : IDisposable
+        {
+            public static readonly NullScope Instance = new();
+            private NullScope() { }
+            public void Dispose() { }
+        }
+        public bool IsEnabled(LogLevel logLevel) => _inner.IsEnabled(logLevel);
+
+        private static string GetPrefix(LogLevel level) => level switch
+        {
+            LogLevel.Information => "ℹ️",
+            LogLevel.Warning => "⚠️",
+            LogLevel.Error => "❌",
+            LogLevel.Debug => "🔍",
+            LogLevel.Trace => "🔹",
+            LogLevel.Critical => "🔥",
+            _ => "🔸"
+        };
+    }
+}

--- a/appsettings.json
+++ b/appsettings.json
@@ -6,41 +6,51 @@
 
   "Jobs": [
     {
-      "JobName": "DiskCleanupJob",
+      "JobName": "PingJob",
 
       // ⏱️ How often the job should run
-      "Interval": "00:01:00",
+      "Interval": "00:00:10",
 
       // ✅ Controls whether this job is enabled and will be scheduled
       "Enabled": true,
 
       // 📝 If true, this specific job will run in preview (dry-run) mode.
       // If global RunAllJobsInPreview is true, this is ignored.
-      "IsPreview": true,
+      "IsPreview": false,
 
       // ⚙️ Job-specific parameters
+      "Parameters": {
+        "Url": "https://google.com"
+      }
+    },
+    {
+      "JobName": "DiskCleanupJob",
+      "Interval": "00:01:00",
+      "Enabled": true,
+      "IsPreview": true,
       "Parameters": {
         "TargetDirectory": "C:\\Temp\\CleanupTest",
         "DeleteOlderThanDays": "3"
       }
     },
     {
-      "JobName": "PingJob",
-      "Interval": "00:00:10",
-      "Enabled": true,
-      "IsPreview": false,
-      "Parameters": {
-        "Url": "https://google.com"
-      }
-    },
-    {
       "JobName": "GitHubStarTrackerJob",
       "Interval": "00:05:00",
-      "IsPreview": false,
       "Enabled": true,
+      "IsPreview": false,
       "Parameters": {
         "Repo": "dotnet/runtime", // Format: owner/repo
         "MinDelta": "1" // Optional: Only log if stars increased by X
+      }
+    },
+    {
+      "JobName": "ApplicationResourceMonitorJob",
+      "Interval": "00:01:00",
+      "Enabled": true,
+      "IsPreview": false,
+      "Parameters": {
+        "MaxMemoryMB": "500",
+        "MaxCpuPercent": "50"
       }
     }
   ]


### PR DESCRIPTION
- Introduced ApplicationResourceMonitorJob to track memory and CPU usage of the current .NET process
- Supports threshold-based alerts via config:
  - MaxMemoryMB
  - MaxCpuPercent
- Preview mode logs current usage without triggering alerts
- CPU usage is sampled over 500ms and averaged across all cores
- Updated roadmap in README to reflect new job

- Improve logging clarity and consistency across jobs
- Fix duplicated logs and enhance job scheduler log output